### PR TITLE
Change how path.data is handled

### DIFF
--- a/core/src/main/java/org/apache/cassandra/service/ElassandraDaemon.java
+++ b/core/src/main/java/org/apache/cassandra/service/ElassandraDaemon.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 Strapdata (http://www.strapdata.com)
  * Contains some code from Elasticsearch (http://www.elastic.co)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -74,8 +74,8 @@ import org.slf4j.LoggerFactory;
  * metadata from cassandra schema DiscoveryService discover ring topology and
  * build routing table await that Cassandra start() (Complet cassandra
  * bootstrap) ElasticSearch start() (Open Elastic http service)
- * 
- * 
+ *
+ *
  * @author vroyer
  *
  */
@@ -140,7 +140,7 @@ public class ElassandraDaemon extends CassandraDaemon {
         }
         
         
-        instance.setup(addShutdownHook, settings, env, pluginList); 
+        instance.setup(addShutdownHook, settings, env, pluginList);
         
         //enable indexing in cassandra.
         ElasticSecondaryIndex.runsElassandra = true;
@@ -168,7 +168,7 @@ public class ElassandraDaemon extends CassandraDaemon {
             logger.error("Failed to set the workload to elasticsearch.",e1);
         }
         
-        super.setup(); // start bootstrap CassandraDaemon 
+        super.setup(); // start bootstrap CassandraDaemon
         super.start(); // start Thrift+RPC service
 
         if (instance.node != null) {
@@ -245,7 +245,7 @@ public class ElassandraDaemon extends CassandraDaemon {
     @Override
     public void stop() {
         super.stop();
-        if (node != null) 
+        if (node != null)
             node.close();
     }
 
@@ -369,12 +369,14 @@ public class ElassandraDaemon extends CassandraDaemon {
         return cassandra_conf;
     }
     
+    /*
     public static String getElasticsearchDataDir() {
         String cassandra_storagedir =  System.getProperty("cassandra_storagedir");
         if (cassandra_storagedir == null)
             cassandra_storagedir = System.getProperty("path.data",getHomeDir()+"/data/elasticsearch.data");
         return cassandra_storagedir + "/elasticsearch.data";
     }
+    */
     
     public static void main(String[] args) {
         try
@@ -425,8 +427,8 @@ public class ElassandraDaemon extends CassandraDaemon {
                         .put("node.name","node0")
                         .put("path.home",getHomeDir())
                         .put("path.conf",getConfigDir())
-                        .put("path.data",getElasticsearchDataDir())
-                        .build(), 
+                        //.put("path.data",getElasticsearchDataDir())
+                        .build(),
                     foreground ? Terminal.DEFAULT : null);
             
             instance.activate(true, env.settings(), env,  Collections.<Class<? extends Plugin>>emptyList());

--- a/core/src/main/java/org/apache/cassandra/service/ElassandraDaemon.java
+++ b/core/src/main/java/org/apache/cassandra/service/ElassandraDaemon.java
@@ -314,7 +314,10 @@ public class ElassandraDaemon extends CassandraDaemon {
         // reloading could cause multiple prompts to the user for values if a system property was specified with a prompt
         // placeholder
         Settings nodeSettings = Settings.settingsBuilder()
+                 // overloadable settings from elasticsearch.yml
+                .put("path.data", getElasticsearchDataDir())
                 .put(settings)
+                // overloadable settings.
                 .put(InternalSettingsPreparer.IGNORE_SYSTEM_PROPERTIES_SETTING, true)
                 .build();
         
@@ -369,14 +372,11 @@ public class ElassandraDaemon extends CassandraDaemon {
         return cassandra_conf;
     }
     
-    /*
+    // The default elasticsearch data directory if path.data is not set from elasticsearch.yml or system properties
     public static String getElasticsearchDataDir() {
-        String cassandra_storagedir =  System.getProperty("cassandra_storagedir");
-        if (cassandra_storagedir == null)
-            cassandra_storagedir = System.getProperty("path.data",getHomeDir()+"/data/elasticsearch.data");
-        return cassandra_storagedir + "/elasticsearch.data";
+        String cassandra_storage = System.getProperty("cassandra.storage", getHomeDir() + File.separator + "data");
+        return cassandra_storage + File.separator + "elasticsearch.data";
     }
-    */
     
     public static void main(String[] args) {
         try
@@ -427,7 +427,6 @@ public class ElassandraDaemon extends CassandraDaemon {
                         .put("node.name","node0")
                         .put("path.home",getHomeDir())
                         .put("path.conf",getConfigDir())
-                        //.put("path.data",getElasticsearchDataDir())
                         .build(),
                     foreground ? Terminal.DEFAULT : null);
             

--- a/distribution/src/main/resources/bin/cassandra
+++ b/distribution/src/main/resources/bin/cassandra
@@ -204,8 +204,6 @@ launch_service()
     cassandra_parms="-Dlogback.configurationFile=$CASSANDRA_CONF/logback.xml"
     cassandra_parms="$cassandra_parms -Dcassandra.logdir=$CASSANDRA_LOGDIR"
     cassandra_parms="$cassandra_parms -Dcassandra.storagedir=$cassandra_storagedir"
-    cassandra_parms="$cassandra_parms -Des.default.path.data=$cassandra_storagedir/elasticsearch.data"
-
 
     # needed by elaticsearch for graphic computations
     JVM_OPTS="$JVM_OPTS -Djava.awt.headless=true"

--- a/distribution/src/main/resources/bin/cassandra
+++ b/distribution/src/main/resources/bin/cassandra
@@ -204,6 +204,8 @@ launch_service()
     cassandra_parms="-Dlogback.configurationFile=$CASSANDRA_CONF/logback.xml"
     cassandra_parms="$cassandra_parms -Dcassandra.logdir=$CASSANDRA_LOGDIR"
     cassandra_parms="$cassandra_parms -Dcassandra.storagedir=$cassandra_storagedir"
+    cassandra_parms="$cassandra_parms -Des.default.path.data=$cassandra_storagedir/elasticsearch.data"
+
 
     # needed by elaticsearch for graphic computations
     JVM_OPTS="$JVM_OPTS -Djava.awt.headless=true"


### PR DESCRIPTION
* A small typo error in `ElassandraDaemon.getElasticsearchDataDir()` was causing troubles in rpm and deb packages, see #103 
* The way `path.data` was enforced by ElassandraDaemon at bootstrap prevented the use of `elasticsearch.yml` to set a different storage location.
* The solution here is to set the `es.default.path.data` system property from `bin/cassandra` with the value `$cassandra_storage/elasticsearch.data`. This way, `path.data` has a strong default value, and can be overridden from the configuration file or from `$JVM_OPTS`.
* `ElassandraDaemon.getElasticsearchDataDir()` is no more used and is now commented out.