### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ cache:
 before_install:
   - wget -qO ecm-ccm-elassandra.zip https://github.com/strapdata/ecm/archive/ccm-elassandra.zip
   - unzip ecm-ccm-elassandra.zip && cd ecm-ccm-elassandra && sudo ./setup.py install
+  - pip install --upgrade pip
   - pip3 install sphinx~=1.8.5 sphinx_rtd_theme
   - sudo fallocate -l 4G /swapfile
   - sudo chmod 600 /swapfile

--- a/build.gradle
+++ b/build.gradle
@@ -636,6 +636,10 @@ allprojects {
 }
 
 allprojects {
+    tasks.withType(JavaCompile).configureEach {
+        options.fork = true
+    }
+
   task checkPart1
   task checkPart2 
   tasks.matching { it.name == "check" }.all { check ->
@@ -657,6 +661,5 @@ gradle.projectsEvaluated {
 }
 
 tasks.getByName('clean').dependsOn('cassandra-realclean')
-
 
 


### PR DESCRIPTION

[Compiler daemon](https://docs.gradle.org/current/userguide/performance.html#compiler_daemon). The Gradle Java plugin allows you to run the compiler as a separate process by setting `options.fork = true`. This feature can lead to much less garbage collection and make Gradle’s infrastructure faster. This project has more than 1000 source files. We can consider enabling this feature.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
